### PR TITLE
Fix #20: disable `autoBackup`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,14 +6,14 @@
   <uses-permission android:name="android.permission.INTERNET" />
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:supportsRtl="false"
       android:name=".ui.SurveyApp"
       android:theme="@style/AppThemeNoActionBar"
-      tools:ignore="AllowBackup,GoogleAppIndexingWarning">
+      tools:ignore="GoogleAppIndexingWarning">
     <activity android:name=".ui.MainActivity">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
From @luongvo's comment in #20 
>Suppress the warning without proper configuration: android:allowBackup (https://medium.com/mindorks/auto-backup-in-android-dont-do-it-unless-you-know-it-cc9fe2f9176b)

Fixed by disable `autoBackup` in AndroidManifest